### PR TITLE
Save and restore window-point

### DIFF
--- a/window-layout.el
+++ b/window-layout.el
@@ -348,7 +348,8 @@ start dividing."
               (goto-char it)
               (recenter 0)))
         (wlf:aif (wlf:window-option-get winfo :window-point)
-            (set-window-point (selected-window) it))))))
+            (with-current-buffer buffer
+              (goto-char it)))))))
 
 (defun wlf:collect-window-edges (winfo-list)
   "[internal] At the end of window laying out, this function is


### PR DESCRIPTION
window-point も wlf で管理するようにしてみました。
wlf:save-current-window-sizes の中で window-point を保存していますが、もっと別な所で保存するか関数名を変更するかしたほうが良いかもしれません。

fixes kiwanami/emacs-window-manager#17
