### PR TITLE
Fix: "Selecting deleted buffer"

### DIFF
--- a/window-layout.el
+++ b/window-layout.el
@@ -604,6 +604,7 @@ programs depend on `wlf:get-window' should watch invocations of
 which is returned by `wlf:layout'. WINFO-NAME is the window name
 which is defined by the argument of `wlf:layout'. BUF is a buffer
 name or object to show in the window."
+  (when (stringp buf) (setq buf (get-buffer buf)))
   (let* ((winfo 
           (wlf:get-winfo 
            winfo-name (wlf:wset-winfo-list wset)))


### PR DESCRIPTION
When wlf:set-buffer get a killed buffer, "Selecting deleted buffer"
error is raised.  This could prevent raising the backtrace window
because wlf may hit the same error again.

発生条件がちゃんと分かっていないので PR するか迷ったんですが、理論的には上記のバグが発生していそう、という事態に(e2wm を使っていて)何度か遭遇しました。 Window の update (plug-in など) が正常に動作せず、デバッガを起動しようとしてもひたすら "Selecting deleted buffer" というメッセージが出て何もできなくなります。 `M-:"` でこのパッチの wlf:set-buffer の定義を評価すると治りました。

しばらく使ってみて、何か問題あればここで報告したいと思います。
