### PR TITLE
Do not set window point if it moves window

### DIFF
--- a/window-layout.el
+++ b/window-layout.el
@@ -349,7 +349,13 @@ start dividing."
               (recenter 0)))
         (wlf:aif (wlf:window-option-get winfo :window-point)
             (with-current-buffer buffer
-              (goto-char it)))))))
+              ;; window-point may not be in visible range.  In that
+              ;; case, do not set point.
+              (let ((win-last-point (save-excursion
+                                      (move-to-window-line -1)
+                                      (point-at-eol))))
+                (when (<= it win-last-point)
+                  (goto-char it)))))))))
 
 (defun wlf:collect-window-edges (winfo-list)
   "[internal] At the end of window laying out, this function is


### PR DESCRIPTION
以下の問題を解決します。
1. sub のあるパースペクティブで、 sub をとじた状態にする
2. sub が開くと見えなくなるであろうポイントに、カーソルをセット
3. sub を開く

ステップ2で居たwindowが上下に移動し、ポイントが中央に来た状態になります。
Emacs 24.1.50.1 で確認しました。
